### PR TITLE
Fixing-adc-errors-updating-readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,47 +2,58 @@
 
 A repository for all EPS related firmware. 
 
-There are currently two main embedded frameworks/sdks supported, primarily [Zephyr](https://docs.zephyrproject.org/2.6.0/introduction/index.html) however in the past [Mbed](https://os.mbed.com/mbed-os/) was used.
+There are currently two main embedded frameworks/sdks supported, primarily [Zephyr](https://docs.zephyrproject.org/latest/introduction/index.html) however in the past [Mbed](https://os.mbed.com/mbed-os/) was used.
+
+Current development uses the Zephyr RTOS.
 
 # Zephyr RTOS Setup
+
+For developing using Zephyr it is recommended you use either OSX or Linux (Ubuntu in particular) as your OS. If you are using Windows it is recommended you dual boot your system to run both Ubuntu and Windows.
 
 ## Windows / Ubuntu Dual Boot
 
 If you choose to develop on linux, here is a guide to dual boot your system to run both windows and ubuntu: [Windows/Ubuntu Dual Boot](https://itsfoss.com/install-ubuntu-1404-dual-boot-mode-windows-8-81-uefi/)
 
-## Zephyr RTOS Install
+## Ubuntu Install
 
-Follow the guide [here](https://docs.zephyrproject.org/2.6.0/getting_started/index.html) to setup Zephyr RTOS, **see section beloow on installing a toolchain** when you get to that step. 
+Follow the guide [here](https://docs.zephyrproject.org/latest/develop/getting_started/index.html) to setup Zephyr RTOS, ensure you are following the Ubuntu instructions selected.
 
-See instructions below on installing the python dependencies in a virtual environment, otherwise follow the setup oultined in the [Getting Started Guide](https://docs.zephyrproject.org/2.6.0/getting_started/index.html).
+Once you reach the section *Get Zephyr and install Python dependencies*, it is recommended you try and install within a virtual environment. 
+
+**Note**: If you run into issues with installing within a virtual environment, try installing globally. 
+
+After either installing within a virtual environment or globally, resume following the Zephyr Getting Started Guide from the *Install Zephyr SDK* section.  
 
 Notes: 
-- It is recommended you use either OSX or Linux (Ubunutu is recommended) for development
 - It is recommneded you install the Zephyr base at the root of your user (`~/zephyrproject`)
 
 See the [Beyond Getting Started Guide](https://docs.zephyrproject.org/3.0.0/guides/beyond-GSG.html) for more information on the setup process. 
 
-## Installing a 3rd Party Toolchain
+## OSX Install 
 
-[Reference](https://docs.zephyrproject.org/3.0.0/getting_started/toolchain_3rd_party_x_compilers.html)
+Follow the guide [here](https://docs.zephyrproject.org/latest/develop/getting_started/index.html) to setup Zephyr RTOS, ensure you are following the macOS instructions selected.
 
-Going to use the GNU arm embedded toolchain since it supports ARM based SoCs.
-Install [gcc-arm-none-eabi-10-2020-q4-major](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads/product-release) from the GNU website. 
+Once you reach the section *Get Zephyr and install Python dependencies*, it is recommended you try and install within a virtual environment. 
 
-Extract and copy the files: 
+**Note**: If you run into issues with installing within a virtual environment, try installing globally. 
+
+After either installing within a virtual environment or globally, resume following the Zephyr Getting Started Guide from the *Install Zephyr SDK* section.  
+
+Notes: 
+- It is recommneded you install the Zephyr base at the root of your user (`~/zephyrproject`)
+
+See the [Beyond Getting Started Guide](https://docs.zephyrproject.org/3.0.0/guides/beyond-GSG.html) for more information on the setup process. 
+
+### Common Errors and Notes
+
+While running some of the steps you may encounter some errors, below are some different steps to try instead: 
+
+When running the pip install, add the --user flag 
 ```
-tar -xf gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2
-mkdir ~/toolchains
-cp -r gcc-arm-none-eabi-10-2020-q4-major ~toolchains 
+pip3 install -r ~/zephyrproject/zephyr/scripts/requirements.txt --user
 ```
 
-Once you have the toolchain, you can add it to your PATH, by setting the following enviroment variables.
-
-Add to `~/.zshrc` or `~/.bashrc`:
-```
-export ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
-export GNUARMEMB_TOOLCHAIN_PATH=~/toolchains/gcc-arm-none-eabi-10-2020-q4-major/
-```
+# Additional Install Instructions
 
 ## Using Minicom
 
@@ -67,24 +78,57 @@ In order to solve this, run the following command:
 ```
 sudo apt remove brltty
 ```
+## Installing a 3rd Party Toolchain
 
-## Using a Virtual Environment
+[Reference](https://docs.zephyrproject.org/3.0.0/getting_started/toolchain_3rd_party_x_compilers.html)
 
-Alternatively, you can use a virtual environment to isolate your dependencies. 
+Going to use the GNU arm embedded toolchain since it supports ARM based SoCs.
+Install [gcc-arm-none-eabi-10-2020-q4-major](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads/product-release) from the GNU website. 
 
-Run the following command to create a virtual environment:
-
-Note: `$ZEPHYR_BASE` refers to the absolute path to the Zephyr base installation.
-```shell
-cd zephyr-apps
-python -m venv venv
-pip install -r $ZEPHYR_BASE/scripts/requirements.txt
+Extract and copy the files: 
+```
+tar -xf gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2
+mkdir ~/toolchains
+cp -r gcc-arm-none-eabi-10-2020-q4-major ~toolchains 
 ```
 
-Activiate the virtual environment:
-```shell
-cd zephyr-apps
-source venv/bin/activate
+Once you have the toolchain, you can add it to your PATH, by setting the following enviroment variables.
+
+Add to `~/.zshrc` or `~/.bashrc`:
+```
+export ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
+export GNUARMEMB_TOOLCHAIN_PATH=~/toolchains/gcc-arm-none-eabi-10-2020-q4-major/
+```
+
+## Virtual Environments
+
+### Create Virtual Enviroment (macOS)
+
+Create: 
+```
+python3 -m venv ~/zephyrproject/.venv
+```
+
+Activate: 
+```
+source ~/zephyrproject/.venv/bin/activate
+```
+
+### Create Virtual Enviroment (Ubuntu)
+
+Install virtualenv:
+```
+sudo apt install python3-venv
+```
+
+Create:
+```
+python3 -m venv ~/zephyrproject/.venv
+```
+
+Activate:
+```
+source ~/zephyrproject/.venv/bin/activate
 ```
 
 # Mbed OS Setup

--- a/README.md
+++ b/README.md
@@ -48,10 +48,36 @@ See the [Beyond Getting Started Guide](https://docs.zephyrproject.org/3.0.0/guid
 
 While running some of the steps you may encounter some errors, below are some different steps to try instead: 
 
-When running the pip install, add the --user flag 
+[1] When running the pip install, add the --user flag 
 ```
 pip3 install -r ~/zephyrproject/zephyr/scripts/requirements.txt --user
 ```
+
+[2] When trying to build a application you may get the following error: 
+```
+FileNotFoundError: [Errno 2] No such file or directory: 'dfu-util'
+```
+
+Try installing `dfu-util` using homebrew: 
+```
+brew install dfu-util
+```
+
+[3] When trying to brew install packages you may get an error as follows: 
+```
+Linking /usr/local/Cellar/libmagic/5.43... 
+Error: Could not symlink share/misc/magic.mgc
+Target /usr/local/share/misc/magic.mgc
+```
+
+Try running the following: 
+```
+sudo chown -R `whoami`:admin /usr/local/share
+brew link --overwrite libmagic
+```
+
+Additional steps if that does not work can be found here: [Homebrew: Could not symlink](https://stackoverflow.com/questions/26647412/homebrew-could-not-symlink-usr-local-bin-is-not-writable)
+
 
 # Additional Install Instructions
 
@@ -78,7 +104,16 @@ In order to solve this, run the following command:
 ```
 sudo apt remove brltty
 ```
+
+## Setting Up SSH Keys
+
+When cloning the repository, clone using `ssh`. If you get a *permission denied* when cloning using SSH or when trying to push to the repository after being added, you may need to setup and add your SSH keys for your local machine, follow the guide below: 
+
+[Generate SSH Keys](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)
+
 ## Installing a 3rd Party Toolchain
+
+(**Note:** This is not required, only for reference)
 
 [Reference](https://docs.zephyrproject.org/3.0.0/getting_started/toolchain_3rd_party_x_compilers.html)
 
@@ -132,6 +167,8 @@ source ~/zephyrproject/.venv/bin/activate
 ```
 
 # Mbed OS Setup
+
+(**Note:** This is not required, only for reference)
 
 For the firmware, we are going to use mbed-os to provide drivers and APIs for a varierty of functions. 
 To get started I would recommend installing Mbed Studio - however the online compiler and CLI are also viable options. 

--- a/zephyr-apps/adc/src/main.c
+++ b/zephyr-apps/adc/src/main.c
@@ -1,12 +1,13 @@
-/*
- * Copyright (c) 2020 Libre Solar Technologies GmbH
- *
- * SPDX-License-Identifier: Apache-2.0
- */
+#include <inttypes.h>
+#include <stddef.h>
+#include <stdint.h>
 
-#include <zephyr/zephyr.h>
-#include <zephyr/sys/printk.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/drivers/adc.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
 
 #if !DT_NODE_EXISTS(DT_PATH(zephyr_user)) || \
 	!DT_NODE_HAS_PROP(DT_PATH(zephyr_user), io_channels)
@@ -22,149 +23,58 @@ static const struct adc_dt_spec adc_channels[] = {
 			     DT_SPEC_AND_COMMA)
 };
 
-#define LABEL_AND_COMMA(node_id, prop, idx) \
-	DT_LABEL(DT_IO_CHANNELS_CTLR_BY_IDX(node_id, idx)),
-
-/* Labels of ADC controllers referenced by the above io-channels. */
-static const char *const adc_labels[] = {
-	DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), io_channels,
-			     LABEL_AND_COMMA)
-};
-
-/*
- * Common settings supported by most ADCs.
- * If for a given channel a configuration is available in devicetree, values
- * for gain, reference, and acquisition time are taken from there instead of
- * those below. Also resolution can be optionally specified together with
- * the channel configuration in devicetree. If it is, that value is used
- * instead of the default one below.
- */
-#define ADC_RESOLUTION		12
-#define ADC_GAIN		ADC_GAIN_1
-#define ADC_REFERENCE		ADC_REF_INTERNAL
-#define ADC_ACQUISITION_TIME	ADC_ACQ_TIME_DEFAULT
-
-static void configure_channel(const struct adc_dt_spec *dt_spec,
-			      uint16_t *vref_mv)
-{
-	/* If a configuration for the channel is specified in devicetree,
-	 * use it, otherwise use default settings that should be suitable
-	 * for most ADCs.
-	 */
-	if (dt_spec->channel_cfg_dt_node_exists) {
-		adc_channel_setup(dt_spec->dev, &dt_spec->channel_cfg);
-
-		/* For the internal reference, use the voltage value returned
-		 * by the dedicated API function. For others, use the value
-		 * from devicetree if available.
-		 */
-		if (dt_spec->channel_cfg.reference == ADC_REF_INTERNAL) {
-			*vref_mv = adc_ref_internal(dt_spec->dev);
-		} else if (dt_spec->vref_mv > 0) {
-			*vref_mv = dt_spec->vref_mv;
-		}
-	} else {
-		struct adc_channel_cfg channel_cfg = {
-			.channel_id       = dt_spec->channel_id,
-			.gain             = ADC_GAIN,
-			.reference        = ADC_REFERENCE,
-			.acquisition_time = ADC_ACQUISITION_TIME,
-		};
-
-		adc_channel_setup(dt_spec->dev, &channel_cfg);
-
-		*vref_mv = adc_ref_internal(dt_spec->dev);
-	}
-}
-
-static void prepare_sequence(struct adc_sequence *sequence,
-			     const struct adc_dt_spec *dt_spec)
-{
-	sequence->channels     = BIT(dt_spec->channel_id);
-	sequence->resolution   = ADC_RESOLUTION;
-	sequence->oversampling = 0;
-
-	if (dt_spec->channel_cfg_dt_node_exists) {
-		if (dt_spec->resolution) {
-			sequence->resolution = dt_spec->resolution;
-		}
-		if (dt_spec->oversampling) {
-			sequence->oversampling = dt_spec->oversampling;
-		}
-	}
-}
-
-static void print_millivolts(int32_t value,
-			     uint16_t vref_mv,
-			     uint8_t resolution,
-			     const struct adc_dt_spec *dt_spec)
-{
-	enum adc_gain gain = ADC_GAIN;
-
-	if (dt_spec->channel_cfg_dt_node_exists) {
-		gain = dt_spec->channel_cfg.gain;
-
-		/*
-		 * For differential channels, one bit less needs to be specified
-		 * for resolution to achieve correct conversion.
-		 */
-		if (dt_spec->channel_cfg.differential) {
-			resolution -= 1;
-		}
-	}
-
-	adc_raw_to_millivolts(vref_mv, gain, resolution, &value);
-	printk(" = %d mV", value);
-}
-
 void main(void)
 {
 	int err;
-	int16_t sample_buffer[1];
+	int16_t buf;
 	struct adc_sequence sequence = {
-		.buffer      = sample_buffer,
+		.buffer = &buf,
 		/* buffer size in bytes, not number of samples */
-		.buffer_size = sizeof(sample_buffer),
+		.buffer_size = sizeof(buf),
 	};
-	uint16_t vref_mv[ARRAY_SIZE(adc_channels)] = { 0 };
 
 	/* Configure channels individually prior to sampling. */
-	for (uint8_t i = 0; i < ARRAY_SIZE(adc_channels); i++) {
+	for (size_t i = 0U; i < ARRAY_SIZE(adc_channels); i++) {
 		if (!device_is_ready(adc_channels[i].dev)) {
-			printk("ADC device not found\n");
+			printk("ADC controller device not ready\n");
 			return;
 		}
 
-		configure_channel(&adc_channels[i], &vref_mv[i]);
+		err = adc_channel_setup_dt(&adc_channels[i]);
+		if (err < 0) {
+			printk("Could not setup channel #%d (%d)\n", i, err);
+			return;
+		}
 	}
 
 	while (1) {
 		printk("ADC reading:\n");
-		for (uint8_t i = 0; i < ARRAY_SIZE(adc_channels); i++) {
-			printk("- %s, channel %d: ",
-				adc_labels[i], adc_channels[i].channel_id);
+		for (size_t i = 0U; i < ARRAY_SIZE(adc_channels); i++) {
+			int32_t val_mv;
 
-			prepare_sequence(&sequence, &adc_channels[i]);
+			printk("- %s, channel %d: ",
+			       adc_channels[i].dev->name,
+			       adc_channels[i].channel_id);
+
+			(void)adc_sequence_init_dt(&adc_channels[i], &sequence);
 
 			err = adc_read(adc_channels[i].dev, &sequence);
 			if (err < 0) {
-				printk("error %d\n", err);
+				printk("Could not read (%d)\n", err);
 				continue;
 			} else {
-				printk("%d", sample_buffer[0]);
+				printk("%"PRId16, buf);
 			}
 
-			/*
-			 * Convert raw reading to millivolts if the reference
-			 * voltage is known.
-			 */
-			if (vref_mv[i] > 0) {
-				print_millivolts(sample_buffer[0],
-						 vref_mv[i],
-						 sequence.resolution,
-						 &adc_channels[i]);
+			/* conversion to mV may not be supported, skip if not */
+			val_mv = buf;
+			err = adc_raw_to_millivolts_dt(&adc_channels[i],
+						       &val_mv);
+			if (err < 0) {
+				printk(" (value in mV not available)\n");
+			} else {
+				printk(" = %"PRId32" mV\n", val_mv);
 			}
-			printk("\n");
 		}
 
 		k_sleep(K_MSEC(1000));

--- a/zephyr-apps/mppt/src/adc.c
+++ b/zephyr-apps/mppt/src/adc.c
@@ -10,95 +10,16 @@ static const struct adc_dt_spec adc_channels[] = {
 			     DT_SPEC_AND_COMMA)
 };
 
-/* Labels of ADC controllers referenced by the above io-channels. */
-static const char *const adc_labels[] = {
-	DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), io_channels,
-			     LABEL_AND_COMMA)
-};
-
-static int16_t sample_buffer[1];
+static int16_t buf;
 static struct adc_sequence sequence = {
-	.buffer      = sample_buffer,
-	
+	.buffer      = &buf,
 	/* buffer size in bytes, not number of samples */
-	.buffer_size = sizeof(sample_buffer),
+	.buffer_size = sizeof(buf),
 };
-static uint16_t vref_mv[ARRAY_SIZE(adc_channels)] = { 0 };
-
-// Configure ADC device struct
-static void configure_channel(const struct adc_dt_spec *dt_spec,
-			      uint16_t *vref_mv)
-{
-	/* If a configuration for the channel is specified in devicetree,
-	 * use it, otherwise use default settings that should be suitable
-	 * for most ADCs.
-	 */
-	if (dt_spec->channel_cfg_dt_node_exists) {
-		adc_channel_setup(dt_spec->dev, &dt_spec->channel_cfg);
-
-		/* For the internal reference, use the voltage value returned
-		 * by the dedicated API function. For others, use the value
-		 * from devicetree if available.
-		 */
-		if (dt_spec->channel_cfg.reference == ADC_REF_INTERNAL) {
-			*vref_mv = adc_ref_internal(dt_spec->dev);
-		} else if (dt_spec->vref_mv > 0) {
-			*vref_mv = dt_spec->vref_mv;
-		}
-	} else {
-		struct adc_channel_cfg channel_cfg = {
-			.channel_id       = dt_spec->channel_id,
-			.gain             = ADC_GAIN,
-			.reference        = ADC_REFERENCE,
-			.acquisition_time = ADC_ACQUISITION_TIME,
-		};
-
-		adc_channel_setup(dt_spec->dev, &channel_cfg);
-
-		*vref_mv = adc_ref_internal(dt_spec->dev);
-	}
-}
-
-static void prepare_sequence(struct adc_sequence *sequence,
-			     const struct adc_dt_spec *dt_spec)
-{
-	sequence->channels     = BIT(dt_spec->channel_id);
-	sequence->resolution   = ADC_RESOLUTION;
-	sequence->oversampling = 0;
-
-	if (dt_spec->channel_cfg_dt_node_exists) {
-		if (dt_spec->resolution) {
-			sequence->resolution = dt_spec->resolution;
-		}
-		if (dt_spec->oversampling) {
-			sequence->oversampling = dt_spec->oversampling;
-		}
-	}
-}
-
-static int32_t get_millivolts(int32_t value, uint16_t vref_mv, uint8_t resolution, const struct adc_dt_spec *dt_spec){
-	
-	enum adc_gain gain = ADC_GAIN;
-	int32_t mv = value;
-
-	if (dt_spec->channel_cfg_dt_node_exists) {
-		gain = dt_spec->channel_cfg.gain;
-
-		/*
-		 * For differential channels, one bit less needs to be specified
-		 * for resolution to achieve correct conversion.
-		 */
-		if (dt_spec->channel_cfg.differential) {
-			resolution -= 1;
-		}
-	}
-
-	adc_raw_to_millivolts(vref_mv, gain, resolution, &mv);
-
-	return mv;
-}
 
 int8_t setup_adc(){
+
+	int8_t err = 0;
 	
 	/* Configure channels individually prior to sampling. */
 	for (uint8_t i = 0; i < ARRAY_SIZE(adc_channels); i++) {
@@ -107,59 +28,47 @@ int8_t setup_adc(){
 			return -ENODEV;
 		}
 
-		configure_channel(&adc_channels[i], &vref_mv[i]);
-		LOG_INF("ADC(%s), channel [%d]: Configured", adc_labels[i], adc_channels[i].channel_id);
+		err = adc_channel_setup_dt(&adc_channels[i]);
+		if (err < 0) {
+			printk("Could not setup channel #%d (%d)\n", i, err);
+			return -ENODEV;
+		}
+		LOG_INF("ADC(%s), channel [%d]: Configured", adc_channels[i].dev->name, adc_channels[i].channel_id);
 	}
 
-	return 0;
+	return err;
 }
 
 void read_adc_channels(){
 
-	int err;
-	int32_t mv = 0;  
+	int err; 
+	int32_t val_mv;
 	
-	for (uint8_t i = 0; i < ARRAY_SIZE(adc_channels); i++) {
-		LOG_INF("- %s, channel %d: ", adc_labels[i], adc_channels[i].channel_id);
+	for (size_t i = 0U; i < ARRAY_SIZE(adc_channels); i++) {
 
-		prepare_sequence(&sequence, &adc_channels[i]);
+		LOG_INF("- %s, channel %d: ",
+				adc_channels[i].dev->name,
+				adc_channels[i].channel_id);
+
+		(void)adc_sequence_init_dt(&adc_channels[i], &sequence);
 
 		err = adc_read(adc_channels[i].dev, &sequence);
 		if (err < 0) {
-			LOG_ERR("error %d\n", err);
+			LOG_INF("Could not read (%d)\n", err);
 			continue;
+		} else {
+			LOG_INF("%"PRId16, buf);
 		}
 
-		/*
-		* Convert raw reading to millivolts if the reference voltage is known.
-		*/
-		if (vref_mv[i] > 0) {
-			mv = get_millivolts(sample_buffer[0], vref_mv[i], sequence.resolution, &adc_channels[i]);
+		/* conversion to mV may not be supported, skip if not */
+		val_mv = buf;
+		err = adc_raw_to_millivolts_dt(&adc_channels[i],
+							&val_mv);
+		if (err < 0) {
+			LOG_INF(" (value in mV not available)\n");
+		} else {
+			LOG_INF(" = %"PRId32" mV\n", val_mv);
 		}
-
-		LOG_INF("millivolts = %d mV", mv);
 	}
-}
-
-int32_t read_specific_adc_channel_mv(uint8_t channel_index){
-
-	int err;
-	int32_t mv = 0;  
-	
-	prepare_sequence(&sequence, &adc_channels[channel_index]);
-
-	err = adc_read(adc_channels[channel_index].dev, &sequence);
-	if (err < 0) {
-		LOG_ERR("error %d\n", err);
-	}
-
-	/*
-	* Convert raw reading to millivolts if the reference voltage is known.
-	*/
-	if (vref_mv[channel_index] > 0) {
-		mv = get_millivolts(sample_buffer[0], vref_mv[channel_index], sequence.resolution, &adc_channels[channel_index]);
-	}
-
-	return mv;
 }
 

--- a/zephyr-apps/mppt/src/adc.h
+++ b/zephyr-apps/mppt/src/adc.h
@@ -1,7 +1,14 @@
-#include <zephyr/zephyr.h>
-#include <zephyr/drivers/adc.h>
+#include <inttypes.h>
+#include <stddef.h>
+#include <stdint.h>
 
-// Find devicetree configurations
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/adc.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
+
 #if !DT_NODE_EXISTS(DT_PATH(zephyr_user)) || \
 	!DT_NODE_HAS_PROP(DT_PATH(zephyr_user), io_channels)
 #error "No suitable devicetree overlay specified"
@@ -10,17 +17,6 @@
 #define DT_SPEC_AND_COMMA(node_id, prop, idx) \
 	ADC_DT_SPEC_GET_BY_IDX(node_id, idx),
 
-#define LABEL_AND_COMMA(node_id, prop, idx) \
-	DT_LABEL(DT_IO_CHANNELS_CTLR_BY_IDX(node_id, idx)),
-
-// ADC Settings Todo: Move this to the overlay file
-#define ADC_RESOLUTION		12
-#define ADC_GAIN		ADC_GAIN_1
-#define ADC_REFERENCE		ADC_REF_INTERNAL
-#define ADC_ACQUISITION_TIME	ADC_ACQ_TIME_DEFAULT
-
 int8_t setup_adc();
 
 void read_adc_channels();
-
-int32_t read_specific_adc_channel_mv(uint8_t channel_index);

--- a/zephyr-apps/mppt/src/main.c
+++ b/zephyr-apps/mppt/src/main.c
@@ -1,6 +1,5 @@
 #include <zephyr/zephyr.h> 
 #include <zephyr/drivers/gpio.h>
-#include <drivers/adc.h>
 #include <zephyr/logging/log.h>
 
 #include "adc.h"


### PR DESCRIPTION
Change:
- Upated ADC sample app and mppt app to reflect new changes zephyr made with ADC 
- Added more content to README to help with onboarding (including handling errors, more guides and info)

To test ADC changes, build the folllowing 2 apps and ensure they build with no errors: 
```
bash new_build.sh -p adc -b blackpill_f411ce
bash new_build.sh -p mppt -b blackpill_f411ce -o overlays/blackpill_f411ce.overlay
```